### PR TITLE
fix: MD033/no-inline-html

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -28,7 +28,10 @@
         "allowed_elements": [
             "a",
             "br",
-            "p"
+            "font",
+            "kbd",
+            "p",
+            "sup"
         ]
     },
     "no-missing-space-atx": true,

--- a/aspnet/aspnet/overview/developing-apps-with-windows-azure/building-real-world-cloud-apps-with-windows-azure/automate-everything.md
+++ b/aspnet/aspnet/overview/developing-apps-with-windows-azure/building-real-world-cloud-apps-with-windows-azure/automate-everything.md
@@ -119,7 +119,7 @@ The first thing the script does is create the web app by calling the `New-AzureW
 
 ### Create the storage account
 
-Then the main script runs the <em>New-AzureStorage.ps1</em> script, specifying "<em>&lt;websitename&gt;</em>storage" for the storage account name, and the same data center location as the web app.
+Then the main script runs the *New-AzureStorage.ps1* script, specifying "*&lt;websitename&gt;*storage" for the storage account name, and the same data center location as the web app.
 
 [!code-powershell[Main](automate-everything/samples/sample4.ps1?highlight=3)]
 

--- a/aspnet/aspnet/overview/owin-and-katana/host-owin-in-an-azure-worker-role.md
+++ b/aspnet/aspnet/overview/owin-and-katana/host-owin-in-an-azure-worker-role.md
@@ -110,7 +110,7 @@ The compute emulator assigns a local IP address to the endpoint. You can find th
 
 [![](host-owin-in-an-azure-worker-role/_static/image10.png)](host-owin-in-an-azure-worker-role/_static/image9.png)
 
-Find the IP address under Service Deployments, deployment [id], Service Details. Open a web browser and navigate to http://<em>address</em>, where <em>address</em> is the IP address assigned by the compute emulator; for example, `http://127.0.0.1:80`. You should see the OWIN welcome page:
+Find the IP address under Service Deployments, deployment [id], Service Details. Open a web browser and navigate to http:\/\/*address*, where *address* is the IP address assigned by the compute emulator; for example, `http://127.0.0.1:80`. You should see the OWIN welcome page:
 
 ![](host-owin-in-an-azure-worker-role/_static/image11.png)
 

--- a/aspnet/identity/overview/features-api/two-factor-authentication-using-sms-and-email-with-aspnet-identity.md
+++ b/aspnet/identity/overview/features-api/two-factor-authentication-using-sms-and-email-with-aspnet-identity.md
@@ -46,8 +46,8 @@ In this section, you'll use NuGet to download a sample we will work with. Start 
    In this tutorial, we'll use [SendGrid](http://sendgrid.com/) to send email and [Twilio](https://www.twilio.com/) or [ASPSMS](https://www.aspsms.com/asp.net/identity/testcredits/) for sms texting. The `Identity.Samples` package installs the code we will be working with.
 3. Set the [project to use SSL](../../../mvc/overview/security/create-an-aspnet-mvc-5-app-with-facebook-and-google-oauth2-and-openid-sign-on.md).
 4. *Optional*: Follow the instructions in my [Email confirmation tutorial](account-confirmation-and-password-recovery-with-aspnet-identity.md) to hook up SendGrid and then run the app and register an email account.
-5. *Optional: *Remove the demo email link confirmation code from the sample (The `ViewBag.Link` code in the account controller. See the `DisplayEmail` and `ForgotPasswordConfirmation` action methods and razor views ).
-6. <em>Optional: *Remove the `ViewBag.Status` code from the Manage and Account controllers and from the *Views\Account\VerifyCode.cshtml</em> and <em>Views\Manage\VerifyPhoneNumber.cshtml</em> razor views. Alternatively, you can keep the `ViewBag.Status` display to test how this app works locally without having to hook up and send email and SMS messages.
+5. *Optional:* Remove the demo email link confirmation code from the sample (The `ViewBag.Link` code in the account controller. See the `DisplayEmail` and `ForgotPasswordConfirmation` action methods and razor views ).
+6. *Optional:* Remove the `ViewBag.Status` code from the Manage and Account controllers and from the *Views\Account\VerifyCode.cshtml* and *Views\Manage\VerifyPhoneNumber.cshtml* razor views. Alternatively, you can keep the `ViewBag.Status` display to test how this app works locally without having to hook up and send email and SMS messages.
 
 > [!NOTE]
 > Warning: If you change any of the security settings in this sample, productions apps will need to undergo a security audit that explicitly calls out the changes made.

--- a/aspnet/index.md
+++ b/aspnet/index.md
@@ -8,6 +8,7 @@ title: ASP.NET Documentation
 ms.date: 08/24/2018
 description: Learn how to develop ASP.NET and ASP.NET web applications. Get documentation, example code, tutorials, and more.
 ---
+<!-- markdownlint-disable MD033 -->
 <div id="main" class="v2">
     <div class="container">
         <h1>ASP.NET Documentation</h1>

--- a/aspnet/mvc/overview/older-versions-1/nerddinner/provide-crud-create-read-update-delete-data-form-entry-support.md
+++ b/aspnet/mvc/overview/older-versions-1/nerddinner/provide-crud-create-read-update-delete-data-form-entry-support.md
@@ -35,7 +35,7 @@ We previously added action methods to DinnersController that implemented support
 | */Dinners/* | GET | Display an HTML list of upcoming dinners. |
 | */Dinners/Details/[id]* | GET | Display details about a specific dinner. |
 
-We will now add action methods to implement three additional URLs: */Dinners/Edit/[id], /Dinners/Create,*and*/Dinners/Delete/[id]*. These URLs will enable support for editing existing Dinners, creating new Dinners, and deleting Dinners.
+We will now add action methods to implement three additional URLs: */Dinners/Edit/[id]*, */Dinners/Create*, and */Dinners/Delete/[id]*. These URLs will enable support for editing existing Dinners, creating new Dinners, and deleting Dinners.
 
 We will support both HTTP GET and HTTP POST verb interactions with these new URLs. HTTP GET requests to these URLs will display the initial HTML view of the data (a form populated with the Dinner data in the case of "edit", a blank form in the case of "create", and a delete confirmation screen in the case of "delete"). HTTP POST requests to these URLs will save/update/delete the Dinner data in our DinnerRepository (and from there to the database).
 
@@ -132,7 +132,7 @@ We'll begin by adding an overloaded "Edit" action method to our DinnersControlle
 
 [!code-csharp[Main](provide-crud-create-read-update-delete-data-form-entry-support/samples/sample9.cs)]
 
-When the [AcceptVerbs] attribute is applied to overloaded action methods, ASP.NET MVC automatically handles dispatching requests to the appropriate action method depending on the incoming HTTP verb. HTTP POST requests to */Dinners/Edit/[id]* URLs will go to the above Edit method, while all other HTTP verb requests to */Dinners/Edit/[id]*URLs will go to the first Edit method we implemented (which did not have an [AcceptVerbs] attribute).
+When the [AcceptVerbs] attribute is applied to overloaded action methods, ASP.NET MVC automatically handles dispatching requests to the appropriate action method depending on the incoming HTTP verb. HTTP POST requests to */Dinners/Edit/[id]* URLs will go to the above Edit method, while all other HTTP verb requests to */Dinners/Edit/[id]* URLs will go to the first Edit method we implemented (which did not have an `[AcceptVerbs]` attribute).
 
 | **Side Topic: Why differentiate via HTTP verbs?** |
 | --- |
@@ -222,7 +222,7 @@ The Html.ValidationMessage() helper method also supports a second parameter that
 
 [!code-aspx[Main](provide-crud-create-read-update-delete-data-form-entry-support/samples/sample18.aspx)]
 
-The above code outputs: *&lt;span class="field-validation-error"&gt;\*&lt;/span&gt;*instead of the default error text when an error is present for the EventDate property.
+The above code outputs: *&lt;span class="field-validation-error"&gt;\*&lt;/span&gt;* instead of the default error text when an error is present for the EventDate property.
 
 ##### Html.ValidationSummary() Helper Method
 

--- a/aspnet/mvc/overview/older-versions-1/nerddinner/provide-crud-create-read-update-delete-data-form-entry-support.md
+++ b/aspnet/mvc/overview/older-versions-1/nerddinner/provide-crud-create-read-update-delete-data-form-entry-support.md
@@ -35,7 +35,7 @@ We previously added action methods to DinnersController that implemented support
 | */Dinners/* | GET | Display an HTML list of upcoming dinners. |
 | */Dinners/Details/[id]* | GET | Display details about a specific dinner. |
 
-We will now add action methods to implement three additional URLs: <em>/Dinners/Edit/[id], /Dinners/Create,</em>and<em>/Dinners/Delete/[id]</em>. These URLs will enable support for editing existing Dinners, creating new Dinners, and deleting Dinners.
+We will now add action methods to implement three additional URLs: */Dinners/Edit/[id], /Dinners/Create,*and*/Dinners/Delete/[id]*. These URLs will enable support for editing existing Dinners, creating new Dinners, and deleting Dinners.
 
 We will support both HTTP GET and HTTP POST verb interactions with these new URLs. HTTP GET requests to these URLs will display the initial HTML view of the data (a form populated with the Dinner data in the case of "edit", a blank form in the case of "create", and a delete confirmation screen in the case of "delete"). HTTP POST requests to these URLs will save/update/delete the Dinner data in our DinnerRepository (and from there to the database).
 
@@ -132,7 +132,7 @@ We'll begin by adding an overloaded "Edit" action method to our DinnersControlle
 
 [!code-csharp[Main](provide-crud-create-read-update-delete-data-form-entry-support/samples/sample9.cs)]
 
-When the [AcceptVerbs] attribute is applied to overloaded action methods, ASP.NET MVC automatically handles dispatching requests to the appropriate action method depending on the incoming HTTP verb. HTTP POST requests to <em>/Dinners/Edit/[id]</em> URLs will go to the above Edit method, while all other HTTP verb requests to <em>/Dinners/Edit/[id]</em>URLs will go to the first Edit method we implemented (which did not have an [AcceptVerbs] attribute).
+When the [AcceptVerbs] attribute is applied to overloaded action methods, ASP.NET MVC automatically handles dispatching requests to the appropriate action method depending on the incoming HTTP verb. HTTP POST requests to */Dinners/Edit/[id]* URLs will go to the above Edit method, while all other HTTP verb requests to */Dinners/Edit/[id]*URLs will go to the first Edit method we implemented (which did not have an [AcceptVerbs] attribute).
 
 | **Side Topic: Why differentiate via HTTP verbs?** |
 | --- |
@@ -222,7 +222,7 @@ The Html.ValidationMessage() helper method also supports a second parameter that
 
 [!code-aspx[Main](provide-crud-create-read-update-delete-data-form-entry-support/samples/sample18.aspx)]
 
-The above code outputs: <em>&lt;span class="field-validation-error"&gt;\*&lt;/span&gt;</em>instead of the default error text when an error is present for the EventDate property.
+The above code outputs: *&lt;span class="field-validation-error"&gt;\*&lt;/span&gt;*instead of the default error text when an error is present for the EventDate property.
 
 ##### Html.ValidationSummary() Helper Method
 

--- a/aspnet/mvc/overview/older-versions-1/nerddinner/use-ajax-to-deliver-dynamic-updates.md
+++ b/aspnet/mvc/overview/older-versions-1/nerddinner/use-ajax-to-deliver-dynamic-updates.md
@@ -108,7 +108,7 @@ To use jQuery we'll first add a script reference to it. Because we are going to 
 
 *Tip: make sure you have installed the JavaScript intellisense hotfix for VS 2008 SP1 that enables richer intellisense support for JavaScript files (including jQuery). You can download it from: http://tinyurl.com/vs2008javascripthotfix*
 
-Code written using JQuery often uses a global "$()" JavaScript method that retrieves one or more HTML elements using a CSS selector. For example, <em>$("#rsvpmsg")</em> selects any HTML element with the id of rsvpmsg, while <em>$(".something")</em> would select all elements with the "something" CSS class name. You can also write more advanced queries like "return all of the checked radio buttons" using a selector query like: <em>$("input[@type=radio][@checked]")</em>.
+Code written using JQuery often uses a global "$()" JavaScript method that retrieves one or more HTML elements using a CSS selector. For example, *$("#rsvpmsg")* selects any HTML element with the id of rsvpmsg, while *$(".something")* would select all elements with the "something" CSS class name. You can also write more advanced queries like "return all of the checked radio buttons" using a selector query like: *$("input[@type=radio][@checked]")*.
 
 Once you've selected elements, you can call methods on them to take action, like hiding them: *$("#rsvpmsg").hide();*
 

--- a/aspnet/mvc/overview/older-versions/hands-on-labs/whats-new-in-aspnet-mvc-4.md
+++ b/aspnet/mvc/overview/older-versions/hands-on-labs/whats-new-in-aspnet-mvc-4.md
@@ -244,11 +244,11 @@ By using the adaptive rendering technique, your site will be **displayed properl
 > The basic format of a media query is: @media \[Scope: all | handheld | print | projection | screen\] ([property:value] and ... [property:value])
 
 
-Examples of media queries: &gt;<strong>@media all and (max-width: 1000px) and (min-width: 700px) {}:</strong> For all the resolutions between 700px and 1000px.
+Examples of media queries: &gt;**@media all and (max-width: 1000px) and (min-width: 700px) {}:** For all the resolutions between 700px and 1000px.
 
-> <strong>@media screen and (min-width: 400px) and (max-width: 700px) { ... }:</strong> Only for screens. The resolution must be between 400 and 700px.
+> **@media screen and (min-width: 400px) and (max-width: 700px) { ... }:** Only for screens. The resolution must be between 400 and 700px.
 > 
-> <strong>@media handheld and (min-width: 20em), screen and (min-width: 20em) { ... }:</strong> For handhelds(mobile and devices) and screens. The minimum width must be greater than 20em.
+> **@media handheld and (min-width: 20em), screen and (min-width: 20em) { ... }:** For handhelds(mobile and devices) and screens. The minimum width must be greater than 20em.
 > 
 > You can find more information about this on the [W3C site](http://www.w3.org/TR/css3-mediaqueries/).
 
@@ -257,7 +257,7 @@ You will now explore how the adaptive rendering works, improving the readability
 
 1. Open the **PhotoGallery.sln** solution you have created at Task 1 and select the **PhotoGallery** project. Press **F5** to run the solution.
 2. Resize the browser's width, setting the windows to half or to less than a quarter of its original size. Notice what happens with the items in the header: Some elements will not appear in the visible area of the header.
-3. Open <strong>Site.css</strong> file from the Visual Studio Solution explorer, located in <strong>Content</strong> project folder. Press <strong>CTRL + F</strong> to open Visual Studio integrated search, and write <strong>@media</strong> to locate the <strong>CSS media query</strong>.
+3. Open **Site.css** file from the Visual Studio Solution explorer, located in **Content** project folder. Press **CTRL + F** to open Visual Studio integrated search, and write **@media** to locate the **CSS media query**.
 
     The media query condition defined in this template works in this way: When the browser's window size is below **850 px**, the CSS rules applied are the ones defined inside this media block.
 
@@ -268,13 +268,13 @@ You will now explore how the adaptive rendering works, improving the readability
 
     ![In the left, the page is applying the @media style, in the right, the style is omitted](whats-new-in-aspnet-mvc-4/_static/image17.png "In the left, the page is applying the @media style, in the right, the style is omitted")
 
-    <em>In the left, the page is applying the @media style, in the right, the style is omitted</em>
+    *In the left, the page is applying the @media style, in the right, the style is omitted*
 
     Now, let's check out what happens on mobile devices:
 
     ![In the left, the page is applying the @media style, in the right, the style is omitted](whats-new-in-aspnet-mvc-4/_static/image18.png "In the left, the page is applying the @media style, in the right, the style is omitted")
 
-    <em>In the left, the page is applying the @media style, in the right, the style is omitted</em>
+    *In the left, the page is applying the @media style, in the right, the style is omitted*
 
     Although you will notice that the changes when the page is rendered in a Web browser are not very significant, when using a mobile device the differences become more obvious. On the left side of the image, we can see that the custom style improved the readability.
 
@@ -537,7 +537,7 @@ In this task, you will update the desktop layout to include the view-switcher. T
     ![View Switcher rendered in desktop view](whats-new-in-aspnet-mvc-4/_static/image32.png "View Switcher rendered in desktop view")
 
     *View Switcher rendered in desktop view*
-7. Switch to the Mobile view again and browse to <strong>About</strong> page (http://localhost[port]/Home/About). Notice that, even if you haven't created an About.Mobile.cshtml view, the About page is displayed using the mobile layout (\_Layout.Mobile.cshtml).
+7. Switch to the Mobile view again and browse to **About** page (http://localhost[port]/Home/About). Notice that, even if you haven't created an About.Mobile.cshtml view, the About page is displayed using the mobile layout (\_Layout.Mobile.cshtml).
 
     ![About page](whats-new-in-aspnet-mvc-4/_static/image33.png "About page")
 
@@ -758,7 +758,7 @@ With code snippets, you have all the code you need at your fingertips. The lab d
 
 You can install **Microsoft Visual Studio Express 2012 for Web** or another &quot;Express&quot; version using the **[Microsoft Web Platform Installer](https://www.microsoft.com/web/downloads/platform.aspx)**. The following instructions guide you through the steps required to install *Visual studio Express 2012 for Web* using *Microsoft Web Platform Installer*.
 
-1. Go to [[https://go.microsoft.com/?linkid=9810169](https://go.microsoft.com/?linkid=9810169)](https://go.microsoft.com/?linkid=9810169). Alternatively, if you already have installed Web Platform Installer, you can open it and search for the product &quot;<em>Visual Studio Express 2012 for Web with Windows Azure SDK</em>&quot;.
+1. Go to [[https://go.microsoft.com/?linkid=9810169](https://go.microsoft.com/?linkid=9810169)](https://go.microsoft.com/?linkid=9810169). Alternatively, if you already have installed Web Platform Installer, you can open it and search for the product &quot;*Visual Studio Express 2012 for Web with Windows Azure SDK*&quot;.
 2. Click on **Install Now**. If you do not have **Web Platform Installer** you will be redirected to download and install it first.
 3. Once **Web Platform Installer** is open, click **Install** to start the setup.
 
@@ -799,7 +799,7 @@ To run your site in a simulated iPhone device you can use the WebMatrix extensio
 <a id="Task_1_-_Installing_WebMatrix_2"></a>
 #### Task 1 - Installing WebMatrix 2
 
-1. Go to [[https://go.microsoft.com/?linkid=9809776](https://go.microsoft.com/?linkid=9809776)](https://go.microsoft.com/?linkid=9810169). Alternatively, if you already have installed Web Platform Installer, you can open it and search for the product &quot;<em>WebMatrix 2</em>&quot;.
+1. Go to [[https://go.microsoft.com/?linkid=9809776](https://go.microsoft.com/?linkid=9809776)](https://go.microsoft.com/?linkid=9810169). Alternatively, if you already have installed Web Platform Installer, you can open it and search for the product &quot;*WebMatrix 2*&quot;.
 2. Click on **Install Now**. If you do not have **Web Platform Installer** you will be redirected to download and install it first.
 3. Once **Web Platform Installer** is open, click **Install** to start the setup.
 
@@ -869,7 +869,7 @@ To run your site in a simulated iPhone device you can use the WebMatrix extensio
 3. In the &quot;Browse With&quot; dialog, click **Add**.
 4. In the &quot;Add Program&quot; dialog, use the following values:
 
-   - <strong>Program</strong>: C:\Users\*{CurrentUser}<em>\AppData\Local\Microsoft\WebMatrix\Extensions\20\iPhoneSimulator\ElectricMobileSim\ElectricMobileSim.exe *(update the path accordingly)</em>
+   - **Program**: C:\Users\*{CurrentUser}*\AppData\Local\Microsoft\WebMatrix\Extensions\20\iPhoneSimulator\ElectricMobileSim\ElectricMobileSim.exe *(update the path accordingly)*
    - **Arguments**: &quot;1&quot;
    - **Friendly name**: iPhone Simulator
 

--- a/aspnet/web-forms/overview/deployment/web-deployment-in-the-enterprise/understanding-the-project-file.md
+++ b/aspnet/web-forms/overview/deployment/web-deployment-in-the-enterprise/understanding-the-project-file.md
@@ -84,7 +84,7 @@ A project file typically needs to provide lots of different pieces of informatio
 [!code-xml[Main](understanding-the-project-file/samples/sample2.xml)]
 
 
-To retrieve a property value, you use the format **$(***PropertyName***)***.*For example, to retrieve the value of the **ServerName** property, you would type:
+To retrieve a property value, you use the format **$(***PropertyName***)***.* For example, to retrieve the value of the **ServerName** property, you would type:
 
 
 [!code-powershell[Main](understanding-the-project-file/samples/sample3.ps1)]

--- a/aspnet/web-forms/overview/deployment/web-deployment-in-the-enterprise/understanding-the-project-file.md
+++ b/aspnet/web-forms/overview/deployment/web-deployment-in-the-enterprise/understanding-the-project-file.md
@@ -84,7 +84,7 @@ A project file typically needs to provide lots of different pieces of informatio
 [!code-xml[Main](understanding-the-project-file/samples/sample2.xml)]
 
 
-To retrieve a property value, you use the format <strong>$(</strong><em>PropertyName</em><strong>)</strong><em>.</em>For example, to retrieve the value of the <strong>ServerName</strong> property, you would type:
+To retrieve a property value, you use the format **$(***PropertyName***)***.*For example, to retrieve the value of the **ServerName** property, you would type:
 
 
 [!code-powershell[Main](understanding-the-project-file/samples/sample3.ps1)]
@@ -186,8 +186,8 @@ Both targets and tasks can include **Condition** attributes. As such, you can ch
 
 Generally speaking, when you create useful tasks and targets, you'll need to refer to the properties and items that you've defined elsewhere in the project file:
 
-- To use a property value, type <strong>$(</strong><em>PropertyName</em><strong>)</strong>, where <em>PropertyName</em> is the name of the <strong>Property</strong> element or the name of the parameter.
-- To use an item, type <strong>@(</strong><em>ItemName</em><strong>)</strong>, where <em>ItemName</em> is the name of the <strong>Item</strong> element.
+- To use a property value, type **$(***PropertyName***)**, where *PropertyName* is the name of the **Property** element or the name of the parameter.
+- To use an item, type **@(***ItemName***)**, where *ItemName* is the name of the **Item** element.
 
 > [!NOTE]
 > Remember that if you create multiple items with the same name, you're building a list. In contrast, if you create multiple properties with the same name, the last property value you provide will overwrite any previous properties with the same name&#x2014;a property can only contain a single value.

--- a/aspnet/web-forms/overview/getting-started/hands-on-labs/using-page-inspector-in-visual-studio-2012.md
+++ b/aspnet/web-forms/overview/getting-started/hands-on-labs/using-page-inspector-in-visual-studio-2012.md
@@ -212,7 +212,7 @@ In this task, you will use the Page inspector and fix some issues the Photo Gall
 2. With Toggle Inspection Mode selected, click close to, but not on, the Register link to open its code.
 
     Notice that the source code of the links is located in the **\_LoginPartial.cshtml** file, not the Index.cshtml nor the \_Layout.cshtml, which are the places you might look in first place. You have been placed directly in the correct source file.
-3. In the **Styles** tab, locate and click the **<section> #login</section>** item, which is the HTML container for these links.
+3. In the **Styles** tab, locate and click the **\<section> #login** item, which is the HTML container for these links.
 
     Notice that the **#login** style is automatically located in **Site.css** after you click. Moreover, the code is now highlighted.
 

--- a/aspnet/web-forms/overview/moving-to-aspnet-20/caching.md
+++ b/aspnet/web-forms/overview/moving-to-aspnet-20/caching.md
@@ -50,7 +50,7 @@ To invalidate the item that was inserted above, simply remove the item that was 
 
 Note that the key of the item that acts as the cache key must be the same as the value added to the array of cache keys.
 
-## Polling-Based SQL Cache Dependencies<em>(Also called Table-Based Dependencies)</em>
+## Polling-Based SQL Cache Dependencies(Also called Table-Based Dependencies)
 
 SQL Server 7 and 2000 use the polling-based model for SQL cache dependencies. The polling-based model uses a trigger on a database table that is triggered when data in the table change. That trigger updates a **changeId** field in the notification table that ASP.NET checks periodically. If the **changeId** field has been updated, ASP.NET knows that the data have changed and it invalidates the cached data.
 

--- a/aspnet/web-forms/overview/moving-to-aspnet-20/master-pages.md
+++ b/aspnet/web-forms/overview/moving-to-aspnet-20/master-pages.md
@@ -65,7 +65,7 @@ To create a new master page:
 **Figure 2**: Creating a New Master Page
 
 
-Notice that the file extension for a master page is <em>.master</em>. This is one of the ways that a master page differs from an ordinary page. The other primary difference is that in lieu of a @Page directive, the master page contains a @Master directive. Switch to Source View for the master page you've just created and review the code.
+Notice that the file extension for a master page is *.master*. This is one of the ways that a master page differs from an ordinary page. The other primary difference is that in lieu of a @Page directive, the master page contains a @Master directive. Switch to Source View for the master page you've just created and review the code.
 
 A new master page will have one ContentPlaceHolder control by default. In most cases, it makes more sense to create the common page elements first and then insert ContentPlaceHolder controls where custom content is desired. In those cases, developers will want to delete the default ContentPlaceHolder control and insert new ones as the page is developed. ContentPlaceHolder controls are not resizable despite the fact that they do display sizing handles. The ContentPlaceHolder control sizes automatically based upon the content that it contains with one exception; if you place a ContentPlaceHolder control inside of a block element such as a table cell, it will size according to the size of the element.
 
@@ -148,7 +148,7 @@ By setting the MasterPageFile property in code, you can apply a particular maste
 
 ## Using the &lt;pages&gt; Element
 
-You can configure a master page for your pages by setting the masterPageFile attribute in the &lt;pages&gt; element of the web.config file. When using this method, keep in mind that web.config files lower in the application structure can override this setting. Any MasterPageFile attribute set in a @Page directive will also override this setting. Using the &lt;pages&gt; element makes it simple to create a <em>master</em> master page that can be overridden if necessary in particular folders or files.
+You can configure a master page for your pages by setting the masterPageFile attribute in the &lt;pages&gt; element of the web.config file. When using this method, keep in mind that web.config files lower in the application structure can override this setting. Any MasterPageFile attribute set in a @Page directive will also override this setting. Using the &lt;pages&gt; element makes it simple to create a *master* master page that can be overridden if necessary in particular folders or files.
 
 ## Properties in Master Pages
 

--- a/aspnet/web-pages/overview/api-reference/asp-net-web-pages-api-reference.md
+++ b/aspnet/web-pages/overview/api-reference/asp-net-web-pages-api-reference.md
@@ -683,7 +683,7 @@ Sends an email message.
 
 ### `WebMail.SmtpServer`
 
-Sets the SMTP server name. Normally you set this property in the<em>\_AppStart</em> page.
+Sets the SMTP server name. Normally you set this property in the *\_AppStart* page.
 
 [!code-html[Main](asp-net-web-pages-api-reference/samples/sample105.html)]
 

--- a/aspnet/web-pages/overview/getting-started/introducing-aspnet-web-pages-2/intro-to-web-pages-programming.md
+++ b/aspnet/web-pages/overview/getting-started/introducing-aspnet-web-pages-2/intro-to-web-pages-programming.md
@@ -156,7 +156,7 @@ Here are a few examples of conditions you can test in an if statement:
 
 [!code-csharp[Main](intro-to-web-pages-programming/samples/sample7.cs)]
 
-You can test variables against values or against expressions by using a <em>logical operator</em> or <em>comparison operator</em>: equal to (==), greater than (&gt;), less than (&lt;), greater than or equal to (&gt;=), and less than or equal to (&lt;=). The != operator means not equal to — for example, if(a != 0) means <em>if</em> <em>a</em><em>is not equal to 0</em>.
+You can test variables against values or against expressions by using a *logical operator* or *comparison operator*: equal to (==), greater than (&gt;), less than (&lt;), greater than or equal to (&gt;=), and less than or equal to (&lt;=). The != operator means not equal to — for example, if(a != 0) means *if a is not equal to 0*.
 
 > [!NOTE]
 > Make sure you notice that the comparison operator for equals to (==) is not the same as =. The = operator is used only to assign values (var a=2). If you mix these operators up, you'll either get an error or you'll get some strange results.

--- a/aspnet/web-pages/overview/getting-started/introducing-aspnet-web-pages-2/layouts.md
+++ b/aspnet/web-pages/overview/getting-started/introducing-aspnet-web-pages-2/layouts.md
@@ -140,7 +140,7 @@ Open the *Movies.cshtml* page again. In the code at the top, add the following l
 
 The `Page` object is available on all *.cshtml* pages and is for this purpose, namely to share information between a page and its layout.
 
-Open the<em>\_Layout.cshtml</em> page. Change the `<title>` element so that it looks like this markup:
+Open the *\_Layout.cshtml* page. Change the `<title>` element so that it looks like this markup:
 
 [!code-html[Main](layouts/samples/sample9.html)]
 

--- a/aspnet/web-pages/overview/getting-started/introducing-razor-syntax-c.md
+++ b/aspnet/web-pages/overview/getting-started/introducing-razor-syntax-c.md
@@ -569,7 +569,7 @@ An operator is a keyword or character that tells ASP.NET what kind of command to
 * * *
 :::row:::
     :::column:::
-        `&&` <code>&#124;&#124;</code>
+        `&&` `||`
     :::column-end:::
     :::column:::
     Logical AND and OR, which are used to link conditions together.

--- a/aspnet/web-pages/overview/mobile/rendering-aspnet-web-pages-sites-for-mobile-devices.md
+++ b/aspnet/web-pages/overview/mobile/rendering-aspnet-web-pages-sites-for-mobile-devices.md
@@ -31,7 +31,7 @@ by [Tom FitzMacken](https://github.com/tfitzmac)
 
 ASP.NET Web Pages lets you create custom displays for rendering content on mobile or other devices.
 
-The simplest way to create device-specific page in an ASP.NET Web Pages site is by using a file-naming pattern like this: <em>FileName.</em><em>Mobile</em><em>.cshtml</em>. You can create two versions of a page (for example, one named <em>MyFile.cshtml</em> and one named <em>MyFile.Mobile.cshtml</em>). At run time, when a mobile device requests <em>MyFile.cshtml</em>, ASP.NET renders the content from <em>MyFile.Mobile.cshtml</em>. Otherwise, <em>MyFile.cshtml</em> is rendered.
+The simplest way to create device-specific page in an ASP.NET Web Pages site is by using a file-naming pattern like this: *FileName.Mobile.cshtml*. You can create two versions of a page (for example, one named *MyFile.cshtml* and one named *MyFile.Mobile.cshtml*). At run time, when a mobile device requests *MyFile.cshtml*, ASP.NET renders the content from *MyFile.Mobile.cshtml*. Otherwise, *MyFile.cshtml* is rendered.
 
 The following example shows how to enable mobile rendering by adding a content page for mobile devices. *Page1.cshtml* contains content plus a navigation sidebar. *Page1.Mobile.cshtml* contains the same content, but omits the sidebar.
 

--- a/aspnet/web-pages/overview/releases/top-features-in-web-pages-2.md
+++ b/aspnet/web-pages/overview/releases/top-features-in-web-pages-2.md
@@ -198,7 +198,7 @@ The following example shows how the assets manager works. The code contains the 
 
 - A custom helper named `MakeNote`. This helper renders a string inside a box by wrapping a `div` element around it that's styled with a border and by adding &quot;Note:&quot; to it. The helper also calls a JavaScript file that adds run-time behavior to the note. Rather than reference the script with a `<script>` tag, the helper registers the script by calling `Assets.AddScript` .
 - A JavaScript file. This is the file that's called by the helper, and it temporarily increases the font size of note items during a `mouseover` event.
-- A content page, which references the*\_SiteLayout* page, renders some content in the body, and then calls the `MakeNote` helper.
+- A content page, which references the *\_SiteLayout* page, renders some content in the body, and then calls the `MakeNote` helper.
 - A *\_SiteLayout* page. This page provides a common header and a page layout structure. It also includes a call to `Assets.GetScripts`, which is how the assets manager renders script calls in a page.
 
 To run the sample:

--- a/aspnet/web-pages/overview/releases/top-features-in-web-pages-2.md
+++ b/aspnet/web-pages/overview/releases/top-features-in-web-pages-2.md
@@ -146,7 +146,7 @@ Add the following script file references inside the `<head>` section of a web pa
 
 The easiest way to get a local copy of the *jquery.validate.unobtrusive.min.js* library is to create a new Web Pages site based on one of the site templates (such as Starter Site). The site created by the template includes *jquery.validate.unobtrusive.js* file in its Scripts folder, from which you can copy it to your site.
 
-If your website uses a<em>\_SiteLayout</em> page to control the page layout, you can include these script references in that page so that validation is available to all content pages. If you want to perform validation only on particular pages, you can use the assets manager to register the scripts on only those pages. To do this, call `Assets.AddScript(path)` in the page that you want to validate and reference each of the script files. Then add a call to `Assets.GetScripts` in the <em>\_SiteLayout</em> page in order to render the registered `<script>` tags. For more information, see the section [Registering Scripts with the Assets Manager](#resmanagement).
+If your website uses a *\_SiteLayout* page to control the page layout, you can include these script references in that page so that validation is available to all content pages. If you want to perform validation only on particular pages, you can use the assets manager to register the scripts on only those pages. To do this, call `Assets.AddScript(path)` in the page that you want to validate and reference each of the script files. Then add a call to `Assets.GetScripts` in the *\_SiteLayout* page in order to render the registered `<script>` tags. For more information, see the section [Registering Scripts with the Assets Manager](#resmanagement).
 
 In the markup for an individual element, call the `Validation.For` method. This method emits attributes that jQuery can hook in order to provide client-side validation. For example:
 
@@ -198,7 +198,7 @@ The following example shows how the assets manager works. The code contains the 
 
 - A custom helper named `MakeNote`. This helper renders a string inside a box by wrapping a `div` element around it that's styled with a border and by adding &quot;Note:&quot; to it. The helper also calls a JavaScript file that adds run-time behavior to the note. Rather than reference the script with a `<script>` tag, the helper registers the script by calling `Assets.AddScript` .
 - A JavaScript file. This is the file that's called by the helper, and it temporarily increases the font size of note items during a `mouseover` event.
-- A content page, which references the<em>\_SiteLayout</em> page, renders some content in the body, and then calls the `MakeNote` helper.
+- A content page, which references the*\_SiteLayout* page, renders some content in the body, and then calls the `MakeNote` helper.
 - A *\_SiteLayout* page. This page provides a common header and a page layout structure. It also includes a call to `Assets.GetScripts`, which is how the assets manager renders script calls in a page.
 
 To run the sample:
@@ -450,7 +450,7 @@ Web Pages 2 lets you create custom displays for rendering content on mobile or o
 
 The `System.Web.WebPages` namespace contains the following classes that let you work with display modes: `DefaultDisplayMode`, `DisplayInfo`, and `DisplayModes`. You can use these classes directly and write code that renders the right output for specific devices.
 
-Alternatively, you can create device-specific pages by using a file-naming pattern like this: <em>FileName.</em><em>Mobile</em><em>.cshtml</em>. For example, you can create two versions of a page, one named <em>MyFile.cshtml</em> and one named <em>MyFile.Mobile.cshtml</em>. At run time, when a mobile device requests <em>MyFile.cshtml</em>, Web Pages renders the content from <em>MyFile.Mobile.cshtml</em>. Otherwise, <em>MyFile.cshtml</em> is rendered.
+Alternatively, you can create device-specific pages by using a file-naming pattern like this: *FileName.Mobile.cshtml*. For example, you can create two versions of a page, one named *MyFile.cshtml* and one named *MyFile.Mobile.cshtml*. At run time, when a mobile device requests *MyFile.cshtml*, Web Pages renders the content from *MyFile.Mobile.cshtml*. Otherwise, *MyFile.cshtml* is rendered.
 
 The following example shows how to enable mobile rendering by adding a content page for mobile devices. *Page1.cshtml* contains content plus a navigation sidebar. *Page1.Mobile.cshtml* contains the same content, but omits the sidebar.
 

--- a/aspnet/web-pages/overview/testing-and-debugging/aspnet-web-pages-razor-troubleshooting-guide.md
+++ b/aspnet/web-pages/overview/testing-and-debugging/aspnet-web-pages-razor-troubleshooting-guide.md
@@ -135,7 +135,7 @@ Substitute the appropriate values for `your-SMTP-server-name`, and so on. Some o
     *A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond*
 
     This error usually means that the application could not connect to the SMTP server. Check the server name and port number.
-- <em>Mailbox unavailable. The server response was: 5.1.0 &lt;someuser@invaliddomain&gt; sender rejected : invalid sender domain</em>
+- *Mailbox unavailable. The server response was: 5.1.0 &lt;someuser@invaliddomain&gt; sender rejected : invalid sender domain*
 
     This message can indicate that the `From` address is not correct or is missing.
 - *The specified string is not in the form required for an email address.*

--- a/aspnet/web-pages/readme/overview.md
+++ b/aspnet/web-pages/readme/overview.md
@@ -250,8 +250,8 @@ This section of the document describes new features, changes, and known issues w
 > 
 >    - Copy *C:\Program Files\Microsoft SQL Server Edition\v4.0\Desktop\System.Data.SqlServerCe.dll*   
 >        **to** *\Bin*
->    - Copy <em>C:\Program Files\Microsoft SQL Server Compact Edition\v4.0\Private\x86\\</em><strong><em>to</em></strong>\Bin\x86*
->    - Copy <em>C:\Program Files\Microsoft SQL Server Compact Edition\v4.0\Private\amd64\\</em>* <strong>to</strong><em>\Bin\amd64</em>
+>    - Copy *C:\Program Files\Microsoft SQL Server Compact Edition\v4.0\Private\x86\\* **to** *\Bin\x86*
+>    - Copy *C:\Program Files\Microsoft SQL Server Compact Edition\v4.0\Private\amd64\\** **to** *\Bin\amd64*
 > 
 > 2. In the root folder of the website, create or open a *web.config* file. (In WebMatrix 1.0, this file type is available if you click **All** in the **Choose a File Type** dialog box.)
 > 3. Add the following element as a child of the `<configuration>` element (not inside the `<system.web>` element):

--- a/aspnet/whitepapers/add-mobile-pages-to-your-aspnet-web-forms-mvc-application.md
+++ b/aspnet/whitepapers/add-mobile-pages-to-your-aspnet-web-forms-mvc-application.md
@@ -234,7 +234,7 @@ Next, note that by adding a second HomeController to your application (i.e., the
 
 [!code-csharp[Main](add-mobile-pages-to-your-aspnet-web-forms-mvc-application/samples/sample9.cs)]
 
-Now the error will go away, and the URL http://<em>yoursite</em>/ will reach the desktop homepage, and http://<em>yoursite</em>/mobile/ will reach the mobile homepage.
+Now the error will go away, and the URL http:\/\/*yoursite*/ will reach the desktop homepage, and http:\/\/*yoursite*/mobile/ will reach the mobile homepage.
 
 ### Redirecting mobile visitors to your mobile area
 

--- a/aspnet/whitepapers/aspnet4/overview.md
+++ b/aspnet/whitepapers/aspnet4/overview.md
@@ -196,7 +196,7 @@ ASP.NET 4 also enables you to configure the characters that are used by the URL 
 
 [!code-xml[Main](overview/samples/sample11.xml)]
 
-By default, the *requestPathInvalidChars* attribute defines eight characters as invalid. (In the string that is assigned to *requestPathInvalidChars* by default*,*the less than (&lt;), greater than (&gt;), and ampersand (&amp;) characters are encoded, because the `Web.config` file is an XML file.) You can customize the set of invalid characters as needed.
+By default, the *requestPathInvalidChars* attribute defines eight characters as invalid. (In the string that is assigned to *requestPathInvalidChars* by default, the less than (&lt;), greater than (&gt;), and ampersand (&amp;) characters are encoded, because the `Web.config` file is an XML file.) You can customize the set of invalid characters as needed.
 
 > [!NOTE]
 > Note ASP.NET 4 always rejects URL paths that contain characters in the ASCII range of 0x00 to 0x1F, because those are invalid URL characters as defined in RFC 2396 of the IETF ([http://www.ietf.org/rfc/rfc2396.txt](http://www.ietf.org/rfc/rfc2396.txt)). On versions of Windows Server that run IIS 6 or higher, the http.sys protocol device driver automatically rejects URLs with these characters.

--- a/aspnet/whitepapers/aspnet4/overview.md
+++ b/aspnet/whitepapers/aspnet4/overview.md
@@ -196,7 +196,7 @@ ASP.NET 4 also enables you to configure the characters that are used by the URL 
 
 [!code-xml[Main](overview/samples/sample11.xml)]
 
-By default, the <em>requestPathInvalidChars</em> attribute defines eight characters as invalid. (In the string that is assigned to <em>requestPathInvalidChars</em> by default<em>,</em>the less than (&lt;), greater than (&gt;), and ampersand (&amp;) characters are encoded, because the `Web.config` file is an XML file.) You can customize the set of invalid characters as needed.
+By default, the *requestPathInvalidChars* attribute defines eight characters as invalid. (In the string that is assigned to *requestPathInvalidChars* by default*,*the less than (&lt;), greater than (&gt;), and ampersand (&amp;) characters are encoded, because the `Web.config` file is an XML file.) You can customize the set of invalid characters as needed.
 
 > [!NOTE]
 > Note ASP.NET 4 always rejects URL paths that contain characters in the ASCII range of 0x00 to 0x1F, because those are invalid URL characters as defined in RFC 2396 of the IETF ([http://www.ietf.org/rfc/rfc2396.txt](http://www.ietf.org/rfc/rfc2396.txt)). On versions of Windows Server that run IIS 6 or higher, the http.sys protocol device driver automatically rejects URLs with these characters.
@@ -622,7 +622,7 @@ The *RouteParameter* class lets you specify route data as a parameter value for 
 
 [!code-aspx[Main](overview/samples/sample46.aspx)]
 
-In this case, the value of the route parameter searchterm will be used for the @companyname parameter in the <em>Select</em> statement.
+In this case, the value of the route parameter searchterm will be used for the @companyname parameter in the *Select* statement.
 
 <a id="0.2__Toc224729037"></a><a id="0.2__Toc253429261"></a><a id="0.2__Toc243304635"></a>
 

--- a/aspnet/whitepapers/mvc3-release-notes.md
+++ b/aspnet/whitepapers/mvc3-release-notes.md
@@ -429,7 +429,7 @@ When the *Html.ValidationMessage* method displays a validation message, it skips
 <a id="_Toc2_10"></a>
 ### Fixed @model Declaration to not Add Whitespace to the Document
 
-In earlier releases, the <em>@model</em> declaration at the top of a view added a blank line to the rendered HTML output. This has been fixed so that the declaration does not introduce whitespace.
+In earlier releases, the *@model* declaration at the top of a view added a blank line to the rendered HTML output. This has been fixed so that the declaration does not introduce whitespace.
 
 <a id="_Toc2_11"></a>
 ### Added "FileExtensions" Property to View Engines to Support Engine-Specific File Names
@@ -456,7 +456,7 @@ In earlier versions, explicit values that were passed to the *RenderAction* meth
 - In previous versions of ASP.NET MVC, action filters were created per request except in a few cases. This behavior was never a guaranteed behavior but merely an implementation detail and the contract for filters was to consider them stateless. In ASP.NET MVC 3, filters are cached more aggressively. Therefore, any custom action filters which improperly store instance state might be broken.
 - The order of execution for exception filters has changed for exception filters that have the same *Order* value. In ASP.NET MVC 2 and earlier, exception filters on the controller that had the same *Order* value as those on an action method were executed before the exception filters on the action method. This would typically be the case when exception filters were applied without a specified *Order* value. In ASP.NET MVC 3, this order has been reversed so that the most specific exception handler executes first. As in earlier versions, if the *Order* property is explicitly specified, the filters are run in the specified order.
 - A new property named *FileExtensions* was added to the *VirtualPathProviderViewEngine* base class. When ASP.NET looks up a view by path (not by name), only views with a file extension contained in the list specified by this new property are considered. This is a breaking change in applications where a custom build provider is registered in order to enable a custom file extension for Web Form views and where the provider references those views by using a full path rather than a name. The workaround is to modify the value of the *FileExtensions* property to include the custom file extension.
-- Custom controller factory implementations that directly implement the <em>IControllerFactory</em> interface must provide an implementation of the new <em>GetControllerSessionBehavior</em><em>method that was added to the interface in this release</em>. In general, it is recommended that you do not implement this interface directly and instead derive your class from <em>DefaultControllerFactory</em>.
+- Custom controller factory implementations that directly implement the *IControllerFactory* interface must provide an implementation of the new *GetControllerSessionBehavior* method that was added to the interface in this release. In general, it is recommended that you do not implement this interface directly and instead derive your class from *DefaultControllerFactory*.
 
 <a id="_Toc2_KI"></a>
 ## Known Issues


### PR DESCRIPTION

- Ignore rule on index page
- Cleanup some em/strong tags, but pleanty remain
- Add elements used in addition to Markdown elements