### PR TITLE
Update real-time-web-applications-with-signalr.md for link to WebCampTrainingKit version which actually contains signalR example

### DIFF
--- a/aspnet/signalr/overview/getting-started/real-time-web-applications-with-signalr.md
+++ b/aspnet/signalr/overview/getting-started/real-time-web-applications-with-signalr.md
@@ -16,7 +16,7 @@ by [Web Camps Team](https://twitter.com/webcamps)
 
 [!INCLUDE [Consider ASP.NET Core SignalR](~/includes/signalr/signalr-version-disambiguation.md)]
 
-[Download Web Camps Training Kit](https://aka.ms/webcamps-training-kit)
+[Download Web Camps Training Kit, October 2015 Release](https://github.com/Microsoft-Web/WebCampTrainingKit/releases/tag/v2015.10.13b)
 
 > Real-time Web applications feature the ability to push server-side content to the connected clients as it happens, in real-time. For ASP.NET developers, **ASP.NET SignalR** is a library to add real-time web functionality to their applications. It takes advantage of several transports, automatically selecting the best available transport given the client and server's best available transport. It takes advantage of **WebSocket**, an HTML5 API that enables bi-directional communication between the browser and server.
 > 
@@ -28,8 +28,7 @@ by [Web Camps Team](https://twitter.com/webcamps)
 > 
 > ![SignalR Architecture](real-time-web-applications-with-signalr/_static/image1.png)
 > 
-> All sample code and snippets are included in the Web Camps Training Kit, available at [https://aka.ms/webcamps-training-kit](https://aka.ms/webcamps-training-kit).
-
+> All sample code and snippets are included in the Web Camps Training Kit, October 2015 Release, available at [https://github.com/Microsoft-Web/WebCampTrainingKit/releases/tag/v2015.10.13b](https://github.com/Microsoft-Web/WebCampTrainingKit/releases/tag/v2015.10.13b).  Please note that the Installer link on that page no longer works; use one of the links under the Assets section instead.
 
 <a id="Overview"></a>
 ## Overview


### PR DESCRIPTION
The link to "Download Web Camps Training Kit" had pointed to the general release page (https://github.com/Microsoft-Web/WebCampTrainingKit/releases), and in the latest version the part related to this article, RealTimeSignalR, had been removed.  Therefore I propose that the links should go to the October 2015 Release (https://github.com/Microsoft-Web/WebCampTrainingKit/releases/tag/v2015.10.13b), where the pertinent source code still exists.
