### PR TITLE
fix: MD031/blanks-around-fences

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,7 @@ DocFX requires:
   ```console
   docfx --serve
   ```
+
 * In a browser, navigate to `http://localhost:8080/group1-dest/`.
 
 ### Mono instructions
@@ -128,6 +129,7 @@ DocFX requires:
   ```console
   brew install mono
   ```
+
 * Download the [latest version of DocFX](https://github.com/dotnet/docfx/releases).
 * Extract the archive to *$HOME/bin/docfx*.
 * Create a pair of aliases for **docfx** in a bash shell. The first alias is used to build the documentation. The second alias is used to build and serve the documentation.
@@ -136,11 +138,13 @@ DocFX requires:
   alias docfx='mono $HOME/bin/docfx/docfx.exe'
   alias docfx-serve='mono $HOME/bin/docfx/docfx.exe --serve'
   ```
+
 * In a command shell, navigate to the *aspnet* folder that contains the *docfx.json* file  and run the following command to build and serve the docs via its alias:
 
   ```console
   docfx-serve
   ```
+
 * In a browser, navigate to `http://localhost:8080/group1-dest/`.
 
 ## Voice and tone

--- a/aspnet/signalr/overview/getting-started/tutorial-getting-started-with-signalr.md
+++ b/aspnet/signalr/overview/getting-started/tutorial-getting-started-with-signalr.md
@@ -76,6 +76,7 @@ This section shows how to use Visual Studio 2017 and SignalR 2 to create an empt
 1. Check that the script references in the code block correspond to the versions of the script files in the project.
 
     Script references from the original code block:
+
     ```html
     <!--Script references. -->
     <!--Reference the jQuery library. -->


### PR DESCRIPTION

Fenced code blocks should be surrounded by blank lines