### PR TITLE
Add .NET universal header

### DIFF
--- a/aspnet/docfx.json
+++ b/aspnet/docfx.json
@@ -44,6 +44,7 @@
       "breadcrumb_path": "/aspnet/breadcrumb/toc.json",
       "ms.prod": "aspnet-framework",
       "ms.topic": "conceptual",
+      "uhfHeaderId": "MSDocsHeader-DotNet",
       "searchScope": [
         "ASP.NET"
       ],


### PR DESCRIPTION
This will put the same header on the ASP.NET docs that is used on the [.NET website](https://dotnet.microsoft.com/), [main .NET docs](https://docs.microsoft.com/en-us/dotnet/), and [EF docs](https://docs.microsoft.com/en-us/ef/).

Here are examples of this setting being used in the other doc sets:
* Main .NET docs https://github.com/dotnet/docs/blob/master/docfx.json#L108
* EF docs https://github.com/aspnet/EntityFramework.Docs/blob/master/entity-framework/docfx.json#L81