### PR TITLE
Update sample6.cs

### DIFF
--- a/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v4/create-an-odata-v4-endpoint/samples/sample6.cs
+++ b/aspnet/web-api/overview/odata-support-in-aspnet-web-api/odata-v4/create-an-odata-v4-endpoint/samples/sample6.cs
@@ -1,3 +1,3 @@
 using ProductService.Models;
-using System.Web.OData.Builder;
-using System.Web.OData.Extensions;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Extensions;


### PR DESCRIPTION
`System.Web.OData` was the namespace for Web API OData version 6.0 and before, but according to [Microsoft OData Stack](http://odata.github.io/) documentation, *"Starting with 7.0, the library ships as two binaries, one for .NET Framework (namespace Microsoft.AspNet.OData) and one for .NET Core (namespace Microsoft.AspNetCore.OData)."* This proposal includes the corrected namespaces.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->