### PR TITLE
C90831: Link is in wrong format

### DIFF
--- a/aspnet/ajax/cdn/overview.md
+++ b/aspnet/ajax/cdn/overview.md
@@ -770,7 +770,7 @@ The following releases of [Globalize](https://github.com/jquery/globalize "Globa
 
 ### Respond Releases on the CDN
 
-The following releases of [https://github.com/scottjehl/Respond](https://github.com/scottjehl/Respond "https://github.com/scottjehl/Respond") Respond are hosted on the CDN:
+The following releases of [Respond](https://github.com/scottjehl/Respond "Respond") are hosted on the CDN:
 
 #### Respond version 1.4.2
 


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
