### PR TITLE
Updated the dead link to "Working with Images"

### DIFF
--- a/aspnet/web-pages/overview/data/working-with-files.md
+++ b/aspnet/web-pages/overview/data/working-with-files.md
@@ -16,7 +16,7 @@ by [Tom FitzMacken](https://github.com/tfitzmac)
 > This article explains how to read, write, append, delete, and upload files in an ASP.NET Web Pages (Razor) site.
 > 
 > > [!NOTE]
-> > If you want to upload images and manipulate them (for example, flip or resize them), see [Working with Images in an ASP.NET Web Pages Site](https://docs.microsoft.com/en-us/aspnet/web-pages/overview/ui-layouts-and-themes/9-working-with-images).
+> > If you want to upload images and manipulate them (for example, flip or resize them), see [Working with Images in an ASP.NET Web Pages Site](/aspnet/web-pages/overview/ui-layouts-and-themes/9-working-with-images).
 > 
 > 
 > **What you'll learn:** 

--- a/aspnet/web-pages/overview/data/working-with-files.md
+++ b/aspnet/web-pages/overview/data/working-with-files.md
@@ -16,7 +16,7 @@ by [Tom FitzMacken](https://github.com/tfitzmac)
 > This article explains how to read, write, append, delete, and upload files in an ASP.NET Web Pages (Razor) site.
 > 
 > > [!NOTE]
-> > If you want to upload images and manipulate them (for example, flip or resize them), see [Working with Images in an ASP.NET Web Pages Site](https://go.microsoft.com/fwlink/?LinkId=202897).
+> > If you want to upload images and manipulate them (for example, flip or resize them), see [Working with Images in an ASP.NET Web Pages Site](https://docs.microsoft.com/en-us/aspnet/web-pages/overview/ui-layouts-and-themes/9-working-with-images).
 > 
 > 
 > **What you'll learn:** 


### PR DESCRIPTION
The link to `[Working with Images in an ASP.NET Web Pages Site` in the `!NOTE` section linked to: https://go.microsoft.com/fwlink/?LinkId=202897
Updated it to link to the new correct url: https://docs.microsoft.com/en-us/aspnet/web-pages/overview/ui-layouts-and-themes/9-working-with-images



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->