### PR TITLE
C95241: Escaping backslash in path to avoid asterisk escaping

### DIFF
--- a/aspnet/whitepapers/side-by-side-with-10.md
+++ b/aspnet/whitepapers/side-by-side-with-10.md
@@ -62,11 +62,11 @@ Each version of the .NET Framework includes a version of the ASP.NET IIS Registr
 
 The Aspnet\_regiis.exe for version 1.0 is located at:
 
-- C:\WINDOWS\Microsoft.NET\Framework\**v1.0.3705**\aspnet\_regiis
+- C:\WINDOWS\Microsoft.NET\Framework\\**v1.0.3705**\aspnet\_regiis
 
 The Aspnet\_regiis.exe for version 1,1 is located at:
 
-- C:\WINDOWS\Microsoft.NET\Framework\**v1.1.4322**\aspnet\_regiis
+- C:\WINDOWS\Microsoft.NET\Framework\\**v1.1.4322**\aspnet\_regiis
 
 The Aspnet\_regiis.exe provides two options for script mapping a Web application:
 


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: Path backslash is escaping asterisk from bold format
@rick-anderson



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->