### PR TITLE
C95241: replacing italic asterisks by underlines

### DIFF
--- a/aspnet/web-forms/overview/deployment/web-deployment-in-the-enterprise/understanding-the-project-file.md
+++ b/aspnet/web-forms/overview/deployment/web-deployment-in-the-enterprise/understanding-the-project-file.md
@@ -77,7 +77,7 @@ A project file typically needs to provide lots of different pieces of informatio
 
 [!code-xml[Main](understanding-the-project-file/samples/sample2.xml)]
 
-To retrieve a property value, you use the format **$(**_PropertyName_**)***.* For example, to retrieve the value of the **ServerName** property, you would type:
+To retrieve a property value, use the format *$(PropertyName)*. For example, to retrieve the value of the **ServerName** property, you would type:
 
 [!code-powershell[Main](understanding-the-project-file/samples/sample3.ps1)]
 

--- a/aspnet/web-forms/overview/deployment/web-deployment-in-the-enterprise/understanding-the-project-file.md
+++ b/aspnet/web-forms/overview/deployment/web-deployment-in-the-enterprise/understanding-the-project-file.md
@@ -77,7 +77,7 @@ A project file typically needs to provide lots of different pieces of informatio
 
 [!code-xml[Main](understanding-the-project-file/samples/sample2.xml)]
 
-To retrieve a property value, you use the format **$(***PropertyName***)***.* For example, to retrieve the value of the **ServerName** property, you would type:
+To retrieve a property value, you use the format **$(**_PropertyName_**)***.* For example, to retrieve the value of the **ServerName** property, you would type:
 
 [!code-powershell[Main](understanding-the-project-file/samples/sample3.ps1)]
 


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Description: Nested asterisks broke format in localized pages



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->