### PR TITLE
Removed unneeded text that trips pc report - how do I doc

### DIFF
--- a/aspnet/web-forms/videos/how-do-i/how-do-i-implement-tracing-in-an-aspnet-web-site.md
+++ b/aspnet/web-forms/videos/how-do-i/how-do-i-implement-tracing-in-an-aspnet-web-site.md
@@ -2,7 +2,7 @@
 uid: web-forms/videos/how-do-i/how-do-i-implement-tracing-in-an-aspnet-web-site
 title: "[How Do I:]  Implement Tracing in an ASP.NET Web Site? | Microsoft Docs"
 author: rick-anderson
-description: "In this video Chris Pels will show you how to implement tracing in an ASP.NET web site to monitor or measure the performance and to diagnose errors. Learn ho..."
+description: "In this video Chris Pels will show you how to implement tracing in an ASP.NET web site to monitor or measure the performance and to diagnose errors."
 ms.author: riande
 ms.date: 11/05/2007
 ms.assetid: b3abbbef-ddac-4c8e-a068-5bab31db5931


### PR DESCRIPTION
Removed half-finished sentence that always trips up the monthly PC check. Very low-pri but was tired of having to look at it every month. ;)   There was just one other instance of this issue (#183), sorry for the separate PR's when I should have grouped.
