### PR TITLE
Tautology in a sentence

### DIFF
--- a/aspnet/webhooks/index.md
+++ b/aspnet/webhooks/index.md
@@ -28,7 +28,7 @@ The code targets ASP.NET Web API 2 and ASP.NET MVC 5 and is available as [OSS on
 
 WebHooks is a pattern which means that it varies how it is used from service to service but the basic idea is the same. You can think of WebHooks as a simple pub/sub model where a user can subscribe to events happening elsewhere. The event notifications are propagated as HTTP POST requests containing information about the event itself.
 
-Typically the HTTP POST request contains a JSON object or HTML form data determined by the WebHook sender including information about the event causing the WebHook to trigger. For example, an example of a WebHook POST request body from [GitHub](http://www.github.com/) looks like this as a result of a new issue being opened in a particular repository:
+Typically the HTTP POST request contains a JSON object or HTML form data determined by the WebHook sender including information about the event causing the WebHook to trigger. For example, a WebHook POST request body from [GitHub](http://www.github.com/) looks like this as a result of a new issue being opened in a particular repository:
 
 ```json
 {


### PR DESCRIPTION
The edited sentence contained the "example" word twice, making it difficult to read and grammatically inaccurate.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->