### PR TITLE
Use redirection rule target file instead of redirection file when include file

### DIFF
--- a/aspnet/mvc/overview/getting-started/introduction/accessing-your-models-data-from-a-controller.md
+++ b/aspnet/mvc/overview/getting-started/introduction/accessing-your-models-data-from-a-controller.md
@@ -13,7 +13,7 @@ msc.type: authoredcontent
 
 by [Rick Anderson]((https://twitter.com/RickAndMSFT))
 
-[!INCLUDE [Tutorial Note](sample/code-location.md)]
+[!INCLUDE [Tutorial Note](index.md)]
 
 In this section, you'll create a new `MoviesController` class and write code that retrieves the movie data and displays it in the browser using a view template.
 

--- a/aspnet/mvc/overview/getting-started/introduction/adding-a-controller.md
+++ b/aspnet/mvc/overview/getting-started/introduction/adding-a-controller.md
@@ -13,7 +13,7 @@ msc.type: authoredcontent
 
 by [Rick Anderson]((https://twitter.com/RickAndMSFT))
 
-[!INCLUDE [Tutorial Note](sample/code-location.md)]
+[!INCLUDE [Tutorial Note](index.md)]
 
 MVC stands for *model-view-controller*. MVC is a pattern for developing applications that are well architected, testable and easy to maintain. MVC-based applications contain:
 

--- a/aspnet/mvc/overview/getting-started/introduction/adding-a-model.md
+++ b/aspnet/mvc/overview/getting-started/introduction/adding-a-model.md
@@ -13,7 +13,7 @@ msc.type: authoredcontent
 
 by [Rick Anderson]((https://twitter.com/RickAndMSFT))
 
-[!INCLUDE [Tutorial Note](sample/code-location.md)]
+[!INCLUDE [Tutorial Note](index.md)]
 
 In this section you'll add some classes for managing movies in a database. These classes will be the &quot;model&quot; part of the ASP.NET MVC app.
 

--- a/aspnet/mvc/overview/getting-started/introduction/adding-a-new-field.md
+++ b/aspnet/mvc/overview/getting-started/introduction/adding-a-new-field.md
@@ -13,7 +13,7 @@ msc.type: authoredcontent
 
 by [Rick Anderson]((https://twitter.com/RickAndMSFT))
 
-[!INCLUDE [Tutorial Note](sample/code-location.md)]
+[!INCLUDE [Tutorial Note](index.md)]
 
 In this section you'll use Entity Framework Code First Migrations to migrate some changes to the model classes so the change is applied to the database.
 

--- a/aspnet/mvc/overview/getting-started/introduction/adding-a-view.md
+++ b/aspnet/mvc/overview/getting-started/introduction/adding-a-view.md
@@ -10,7 +10,7 @@ uid: mvc/overview/getting-started/introduction/adding-a-view
 
 by [Rick Anderson]((https://twitter.com/RickAndMSFT))
 
-[!INCLUDE [Tutorial Note](sample/code-location.md)]
+[!INCLUDE [Tutorial Note](index.md)]
 
 In this section you're going to modify the `HelloWorldController` class to use view template files to cleanly encapsulate the process of generating HTML responses to a client. 
 

--- a/aspnet/mvc/overview/getting-started/introduction/adding-search.md
+++ b/aspnet/mvc/overview/getting-started/introduction/adding-search.md
@@ -11,7 +11,7 @@ msc.type: authoredcontent
 ---
 # Search
 
-[!INCLUDE [Tutorial Note](sample/code-location.md)]
+[!INCLUDE [Tutorial Note](index.md)]
 
 ## Adding a Search Method and Search View
 

--- a/aspnet/mvc/overview/getting-started/introduction/adding-validation.md
+++ b/aspnet/mvc/overview/getting-started/introduction/adding-validation.md
@@ -13,7 +13,7 @@ msc.type: authoredcontent
 
 by [Rick Anderson]((https://twitter.com/RickAndMSFT))
 
-[!INCLUDE [Tutorial Note](sample/code-location.md)]
+[!INCLUDE [Tutorial Note](index.md)]
 
 In this section you'll add validation logic to the `Movie` model, and you'll ensure that the validation rules are enforced any time a user attempts to create or edit a movie using the application.
 

--- a/aspnet/mvc/overview/getting-started/introduction/creating-a-connection-string.md
+++ b/aspnet/mvc/overview/getting-started/introduction/creating-a-connection-string.md
@@ -13,7 +13,7 @@ msc.type: authoredcontent
 
 by [Rick Anderson]((https://twitter.com/RickAndMSFT))
 
-[!INCLUDE [Tutorial Note](sample/code-location.md)]
+[!INCLUDE [Tutorial Note](index.md)]
 
 ## Creating a Connection String and Working with SQL Server LocalDB
 

--- a/aspnet/mvc/overview/getting-started/introduction/examining-the-details-and-delete-methods.md
+++ b/aspnet/mvc/overview/getting-started/introduction/examining-the-details-and-delete-methods.md
@@ -13,7 +13,7 @@ msc.type: authoredcontent
 
 by [Rick Anderson]((https://twitter.com/RickAndMSFT))
 
-[!INCLUDE [Tutorial Note](sample/code-location.md)]
+[!INCLUDE [Tutorial Note](index.md)]
 
 In this part of the tutorial, you'll examine the automatically generated `Details` and `Delete` methods.
 

--- a/aspnet/mvc/overview/getting-started/introduction/examining-the-edit-methods-and-edit-view.md
+++ b/aspnet/mvc/overview/getting-started/introduction/examining-the-edit-methods-and-edit-view.md
@@ -13,7 +13,7 @@ msc.type: authoredcontent
 
 by [Rick Anderson]((https://twitter.com/RickAndMSFT))
 
-[!INCLUDE [Tutorial Note](sample/code-location.md)]
+[!INCLUDE [Tutorial Note](index.md)]
 
 In this section, you'll examine the generated `Edit` action methods and views for the movie controller. But first we'll take a short diversion to make the release date look better. Open the *Models\Movie.cs* file and add the highlighted lines shown below:
 


### PR DESCRIPTION
The redirection file [`sample/code-location.md`](https://github.com/aspnet/AspNetDocs/blob/master/.openpublishing.redirection.json#L19) will be redirected to file [`index.md`](https://github.com/aspnet/AspNetDocs/blob/master/.openpublishing.redirection.json#L20) after publish. If we use redirection file as include file, the include will not work on [published pages](https://review.docs.microsoft.com/en-us/aspnet/mvc/overview/getting-started/introduction/accessing-your-models-data-from-a-controller?branch=master) for both docfx v2 and docfx v3. Current docfx v2 will not throw any error for this case but docfx v3 will throw error for this.

This pull request is created to fix above issue and for docfx v3 migration.