### PR TITLE
Clarify what Json.NET is

### DIFF
--- a/aspnet/web-api/overview/advanced/calling-a-web-api-from-a-net-client.md
+++ b/aspnet/web-api/overview/advanced/calling-a-web-api-from-a-net-client.md
@@ -58,7 +58,7 @@ The preceding command adds the following NuGet packages to the project:
 * Microsoft.AspNet.WebApi.Client
 * Newtonsoft.Json
 
-Json.NET is a popular high-performance JSON framework for .NET.
+Netwonsoft.Json (also known as Json.NET) is a popular high-performance JSON framework for .NET.
 
 <a id="AddModelClass"></a>
 ## Add a Model Class


### PR DESCRIPTION
This beginners guide leads you to install Newtonsoft.Json, and then straight away starts referring to the same package as Json.NET. Added clarification, for the unfamiliar. 🙂 