### PR TITLE
Check for null useragent strings

### DIFF
--- a/aspnet/SameSite/sample/SameSiteCheck.cs
+++ b/aspnet/SameSite/sample/SameSiteCheck.cs
@@ -23,6 +23,11 @@ namespace WebApplication64
     {
         public static bool DisallowsSameSiteNone(string userAgent)
         {
+            // check if a null or empty string has been passed in, since this
+            // will cause further interrogation of the useragent to fail
+             if (String.IsNullOrWhiteSpace(userAgent))
+                return false;
+            
             // Cover all iOS based browsers here. This includes:
             // - Safari on iOS 12 for iPhone, iPod Touch, iPad
             // - WkWebview on iOS 12 for iPhone, iPod Touch, iPad

--- a/aspnet/SameSite/sample/SameSiteCheck.cs
+++ b/aspnet/SameSite/sample/SameSiteCheck.cs
@@ -1,4 +1,4 @@
-﻿using System.Web;
+using System.Web;
 
 namespace WebApplication64
 {

--- a/aspnet/SameSite/sample/SameSiteCheck.cs
+++ b/aspnet/SameSite/sample/SameSiteCheck.cs
@@ -23,8 +23,8 @@ namespace WebApplication64
     {
         public static bool DisallowsSameSiteNone(string userAgent)
         {
-            // check if a null or empty string has been passed in, since this
-            // will cause further interrogation of the useragent to fail
+            // Check if a null or empty string has been passed in, since this
+            // will cause further interrogation of the useragent to fail.
              if (String.IsNullOrWhiteSpace(userAgent))
                 return false;
             


### PR DESCRIPTION
Having run the DisallowSameSiteNone method in production, there is an edge case that is not handled: if the useragent string is null, which can happen on an Internet facing website, the method will fail causing an unhandled exception, and hence filling the logs of the web.server with EventIDs 1309. Added a check on lines 28 and 29 to catch this.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->