### PR TITLE
add xref_query_tags to .openpublishing.publish.config.json

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -17,6 +17,10 @@
       "version": 0
     }
   ],
+  "xref_query_tags": [
+    "/dotnet",
+    "/aspnet/core"
+  ],
   "notification_subscribers": [],
   "sync_notification_subscribers": [],
   "branches_to_filter": [],


### PR DESCRIPTION
In v2, `xrefservice` can be defined in `docfx.json` then the user can query `uid` universally, which will be removed during the migration to v3 and `xref_query_tags` should be added to `.openpublishing.publish.config.json`.

We created this pull request to make the repository ready to migrate to docfx v3. This PR will not change any published pages.