### PR TITLE
move xref_query_tags to docset config part in .openpublishing.publish.config.json

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -12,14 +12,14 @@
         "ManagedReference": "Content",
         "RestApi": "Content"
       },
+      "xref_query_tags": [
+        "/dotnet",
+        "/aspnet/core"
+      ],
       "build_entry_point": "docs",
       "template_folder": "_themes",
       "version": 0
     }
-  ],
-  "xref_query_tags": [
-    "/dotnet",
-    "/aspnet/core"
   ],
   "notification_subscribers": [],
   "sync_notification_subscribers": [],


### PR DESCRIPTION
As mentioned reason in #320, I have added `xref_query_tags` in .openpublishing.publish.config.json, however, the `xref_query_tags` is docset level config, it should be added to publish docset part in .openpublishing.publish.config.json. 

I created this Pull Request to fix the issue in #320 and unblock the docfx v3 migration, sorry for bringing the inconvenience. The pull request will not affect any published pages