### PR TITLE
remove not needed config `xrefService` to keep config clean

### DIFF
--- a/aspnet/docfx.json
+++ b/aspnet/docfx.json
@@ -35,9 +35,6 @@
     ],
     "overwrite": [],
     "externalReference": [],
-    "xrefService": [
-      "https://xref.docs.microsoft.com/query?uid={uid}"
-    ],
     "globalMetadata": {
       "_navPath": "/foo",
       "_navRel": "/foo",


### PR DESCRIPTION

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

The `xrefService` is not needed as mentioned in #320 . Remove the config to make config clean and unblock docfx v3 migration.